### PR TITLE
Charmhelpers cleanup and other fixes

### DIFF
--- a/hooks/setup.py
+++ b/hooks/setup.py
@@ -14,13 +14,3 @@ def pre_install():
         subprocess.check_call(['hooks/setup.sh'])
         subprocess.check_call("pip install -r hooks/python-pkgs.txt",
                               shell=True)
-
-        from path import path
-
-        # temporary dev hack
-        for lib in ('src/ansiblecharm'):
-            pth = str(path(os.environ['CHARM_DIR']) / lib)
-            sys.path.append(pth)
-
-        from ansiblecharm import helpers
-        helpers.write_hosts_file()

--- a/hooks/setup.py
+++ b/hooks/setup.py
@@ -8,7 +8,6 @@ def pre_install():
     Do any setup required before the install hook.
     """
     try:
-        import charmhelpers  # noqa
         import ansiblecharm  # noqa
         from path import path  # noqa
     except ImportError:
@@ -19,7 +18,7 @@ def pre_install():
         from path import path
 
         # temporary dev hack
-        for lib in ('src/ansiblecharm', 'src/charmhelpers'):
+        for lib in ('src/ansiblecharm'):
             pth = str(path(os.environ['CHARM_DIR']) / lib)
             sys.path.append(pth)
 

--- a/playbooks/config-changed.yaml
+++ b/playbooks/config-changed.yaml
@@ -1,4 +1,6 @@
 ---
+- include: installation-status.yaml
+
 - name: enforce latest docker
   when: latest == true and latest_installed == "False"
   include: latest-docker.yaml

--- a/playbooks/latest-docker.yaml
+++ b/playbooks/latest-docker.yaml
@@ -13,3 +13,6 @@
 
 - name: Install required packages.
   apt: name=lxc-docker-{{ version }} state=present update_cache=yes
+
+- set_fact:
+    docker_version_name: docker

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -1,6 +1,7 @@
 - hosts: all
   vars:
     opts_yaml: /etc/ansible/docker-opts.yaml
+    docker_version_name: false
   handlers:
     - name: restart docker
       service: "name={{docker_version_name}} state=restarted"
@@ -12,7 +13,6 @@
     - name: Check Installation Status
       include: installation-status.yaml
       tags:
-        - config-changed
         - network-relation-changed
         - stop
 

--- a/playbooks/universe-docker.yaml
+++ b/playbooks/universe-docker.yaml
@@ -20,3 +20,5 @@
 - name: Add ubuntu to Docker group
   user: name=ubuntu state=present groups="docker"
 
+- set_fact:
+    docker_version_name: docker.io


### PR DESCRIPTION
- Removes now unnecessary sys.modules hack for charmhelpers
- remove inventory file creation (handled by ansiblecharm)
- fixes issue where "docker_version_name" being unset causes "config-changed" to fail on first run