### PR TITLE
Compose

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,4 +11,9 @@ options:
     description: |
       When latest = true, specify the version to install from the PPA.
       latest = false will always assume use the current stable in distro.
+  compose:
+    type: boolean
+    default: true
+    description: |
+        Install docker compose, the formation launch utility
 

--- a/hooks/setup.sh
+++ b/hooks/setup.sh
@@ -4,4 +4,6 @@ set -e
 apt-get install -y \
     python-dev \
     python-pip \
-    git \
+    git
+
+easy_install -U pip

--- a/playbooks/config-changed.yaml
+++ b/playbooks/config-changed.yaml
@@ -31,4 +31,4 @@
 
 - name: Install docker compose
   include: install-compose.yaml
-  when: compose == "True"
+  when: compose == true

--- a/playbooks/config-changed.yaml
+++ b/playbooks/config-changed.yaml
@@ -28,3 +28,7 @@
   notify:
     - calculate docker opts
     - render docker defaults
+
+- name: Install docker compose
+  include: install-compose.yaml
+  when: compose == "True"

--- a/playbooks/install-compose.yaml
+++ b/playbooks/install-compose.yaml
@@ -1,0 +1,4 @@
+---
+
+- name: pip install docker-compose
+  pip: name=docker-compose version=compose_version

--- a/playbooks/install-compose.yaml
+++ b/playbooks/install-compose.yaml
@@ -1,4 +1,4 @@
 ---
 
 - name: pip install docker-compose
-  pip: name=docker-compose version=compose_version
+  pip: name=docker-compose


### PR DESCRIPTION
Adds support for installing docker compose to the base charm delivery pattern.

This offers up interesting paths to launching containers and container configuration from docker-compose.yaml files. (consumeable in actions, charms, etc.)