### PR TITLE
fix apt package not found (404)

### DIFF
--- a/hooks/setup.sh
+++ b/hooks/setup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+apt-get update
+
 apt-get install -y \
     python-dev \
     python-pip \


### PR DESCRIPTION
Using a long running vagrant here to test out juju charms (more than a week
old). When not doing an apt-get update it will try to install old packages
which are not available (404).